### PR TITLE
Graceful timestamp fallback

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -28,6 +28,9 @@ var createPatchedLoad = function(files, originalLoadFn) {
 
     if (files.hasOwnProperty(url)) {
       url = url + '?' + files[url];
+    } else if (url.indexOf('/base/') !== 0) {
+      console.warn('There is no timestamp for ' + url + '!');
+      url = url + '?' + Date.now();
     } else {
       console.error('There is no timestamp for ' + url + '!');
     }

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -26,6 +26,13 @@ describe('adapter requirejs', function() {
     expect(originalLoadSpy.argsForCall[0][2]).toBe('/base/other/file.js');
   });
 
+  it('should append timestamp if not found and not in /base/ path', function() {
+    load('context', 'module', '/custom/proxy/path/other/file.js');
+
+    expect(originalLoadSpy).toHaveBeenCalled();
+    expect(originalLoadSpy.argsForCall[0][2]).toMatch(/^\/custom\/proxy\/path\/other\/file.js\?(\d+)$/);
+  });
+
 
   describe('normalizePath', function() {
 


### PR DESCRIPTION
Let me cite the commit message of the main commit to describe this change

```
if a timestamp for a give file is not found, add the current time as
timestamp to make the browser always reload the file from the server and
not serve a cached version.

In case a file is requested, that is not in the files array, it is
impossible to tell the browser not to use a cached version. If the file
has been changed meanwhile, the tests will still run with an old
version, which might be unwanted. The user is informed about this by a
warning in the development console if the file is not in the base path.
A timestamp is added in this case. If the file is located within the
base path, the user is informed by an error message and no timestamp is
appended.

It is a valid use-case to not have files in the files array, that should
be served. The files might be served by a proxy server (karma itself
provides the possibility to specify a proxy server for a specific
directory). It might not possible for karma to detect any changes in the
files, served by the proxy. Therefor no caching should be done for these
files and the timestamp should always be attached.
```
