### PR TITLE
Changed RegExp that checks whether requirejs should add ".js" to module path.

### DIFF
--- a/src/adapter.wrapper
+++ b/src/adapter.wrapper
@@ -7,5 +7,7 @@ karma.loaded = function() {};
 
 // patch require.js
 requirejs.load = createPatchedLoad(karma.files, requirejs.load);
+// removed from RegExp "^\/|"
+requirejs.jsExtRegExp = /:|\?|\.js$/;
 
 })(window.__karma__, window.requirejs);


### PR DESCRIPTION
All paths in karma starts with a slash so karma-requirejs have problem with loading module created by user. My PR changes the default behavior of requirejs to correctly interpret the path provided by karma.
