### PR TITLE
Modified adapter to not log error when a route is not absolute

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -5,7 +5,7 @@
 var normalizePath = function(path) {
   var normalized = [];
   var parts = path.split('/');
-
+  
   for (var i = 0; i < parts.length; i++) {
     if (parts[i] === '.') {
       continue;
@@ -19,7 +19,12 @@ var normalizePath = function(path) {
     normalized.push(parts[i]);
   }
 
-  return normalized.join('/');
+  var url = normalized.join('/');
+  if (url.charAt(0) !== '/') {
+    url = '/' + url;
+  }
+
+  return url;
 };
 
 var createPatchedLoad = function(files, originalLoadFn) {


### PR DESCRIPTION
The adapter caching system only works with absolute routes (those than start with '/') if an relative route is used `base/src/module.js` Karma is always logging one error per module.

I did it just by adding '/' to the route if it is not relative, I could've made it more flexible using document.location but I think Karma always opens html files in server's root directory so it's not needed. But I can add it.