### PR TITLE
Allow configuration of path to require.js file instead of relying on the npm package 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,22 @@
-var requirejsPath, createPattern;
+var path = require('path');
 
-createPattern = function(path) {
-  return {pattern: path, included: true, served: true, watched: false};
+function createPattern(path) {
+    return {pattern: path, included: true, served: true, watched: false};
+}
+
+function requirejsPath() {
+    return path.dirname(require.resolve('requirejs')) + '/../require.js';
+}
+
+var initRequireJs = function(files, config, base) {
+    var requirejs = config && config.path ? path.resolve(base, config.path) : requirejsPath();
+
+    files.unshift(createPattern(__dirname + '/adapter.js'));
+    files.unshift(createPattern(config && config.path ? (base + '/' + config.path) : requirejsPath));
 };
 
-requirejsPath = require('path').dirname(require.resolve('requirejs')) + '/../require.js';
-
-var initRequireJs = function(files) {
-  files.unshift(createPattern(__dirname + '/adapter.js'));
-  files.unshift(createPattern(requirejsPath));
-};
-
-initRequireJs.$inject = ['config.files'];
+initRequireJs.$inject = ['config.files', 'config.requirejsFramework', 'config.basePath'];
 
 module.exports = {
-  'framework:requirejs': ['factory', initRequireJs]
+    'framework:requirejs': ['factory', initRequireJs]
 };


### PR DESCRIPTION
This would allow people to use requirejs from a source other than npm. (My specific use-case is the desire to use https://github.com/tkissing/reqwirejs instead, so I can easily mock dependencies.)

I used the Google form to submit the Google Individual CLA stuff, but haven't heard back from them yet :(
