### PR TITLE
The adapter should prepend requirejs baseUrl if path is relative

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -2,8 +2,13 @@
 // to take advantage of karma's heavy caching
 // it would work even without this hack, but with reloading all the files all the time
 
-var normalizePath = function(path) {
+var normalizePath = function(path, context) {
   var normalized = [];
+
+  if (context && context.config && context.config.baseUrl && !/^https?:\/\/|^\//i.test(path)) {
+      path = context.config.baseUrl + path;
+  }
+
   var parts = path.split('/');
 
   for (var i = 0; i < parts.length; i++) {
@@ -26,7 +31,7 @@ var createPatchedLoad = function(files, originalLoadFn, locationPathname) {
   var IS_DEBUG = /debug\.html$/.test(locationPathname);
 
   return function(context, moduleName, url) {
-    url = normalizePath(url);
+    url = normalizePath(url, context);
 
     if (files.hasOwnProperty(url)) {
       if (!IS_DEBUG) {

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -3,6 +3,11 @@ describe('adapter requirejs', function() {
   var files = {
     '/base/some/file.js': '12345'
   };
+  var context = {
+    config: {
+      baseUrl: '/base/'
+    }
+  };
 
   beforeEach(function() {
     spyOn(console, 'error');
@@ -48,6 +53,13 @@ describe('adapter requirejs', function() {
     expect(console.error.mostRecentCall.args[0]).toMatch(/^There is no timestamp for /);
   });
 
+  it('should prepend requirejs baseUrl if path is relative and baseUrl is known', function() {
+    load(context, 'module', 'some/file.js');
+
+    expect(originalLoadSpy).toHaveBeenCalled();
+    expect(originalLoadSpy.argsForCall[0][2]).toBe('/base/some/file.js?12345');
+  });
+
 
   describe('normalizePath', function() {
 
@@ -58,6 +70,10 @@ describe('adapter requirejs', function() {
 
     it('should preserve .. in the beginning of the path', function() {
       expect(normalizePath('../../a/file.js')).toBe('../../a/file.js');
+    });
+
+    it('should prepend requirejs baseUrl if path is relative and baseUrl is known', function() {
+      expect(normalizePath('a/../b/./../x.js', context)).toBe('/base/x.js');
     });
   });
 });


### PR DESCRIPTION
The adapter should prepend requirejs baseUrl if path is relative and baseUrl is known.

With this change the test files can be added as relative paths. This solves the problem where requirejs does not add '.js' to absolute paths.

This can be done in main-test.js:

``` javascript
var testFileRe = new RegExp("^/base/test/src/.*\\.js$");

var tests = [];

for (var file in __karma__.files) {
    if (__karma__.files.hasOwnProperty(file)) {
        if (testFileRe.test(file)) {
            tests.push(file.replace(/^\/base\//, ""));
        }
    }
}

requirejs.config({
    baseUrl: "/base",
    deps: tests,
    callback: __karma__.start
});
```
