### PR TITLE
Changed the documentation URL to match Karma version 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Check out examples on how to configure RequireJS with Karma:
 - Karma's e2e test https://github.com/karma-runner/karma/tree/master/test/e2e/requirejs
-- Karma's docs http://karma-runner.github.io/0.8/plus/RequireJS.html
+- Karma's docs https://karma-runner.github.io/0.12/plus/requirejs.html
 - Kim's example project https://github.com/kjbekkelund/karma-requirejs
 
 


### PR DESCRIPTION
Actual: "Karma's docs http://karma-runner.github.io/0.8/plus/RequireJS.html"
Expected: "Karma's docs http://karma-runner.github.io/0.12/plus/requirejs.html" *OR*
"Karma's docs http://karma-runner.github.io/0.12/plus/RequireJS.html"

Also links from the 0.8/plus/RequireJS.html to the 0.12 version are broken due to differences in letter captitalization. Signed-off-by: Bogdan Bivolaru <osbiv@yahoo.com>