### PR TITLE
Update README.md to point to latest Karma docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Check out examples on how to configure RequireJS with Karma:
 - Karma's e2e test https://github.com/karma-runner/karma/tree/master/test/e2e/requirejs
-- Karma's docs http://karma-runner.github.io/0.8/plus/RequireJS.html
+- Karma's docs http://karma-runner.github.io/0.12/plus/requirejs.html
 - Kim's example project https://github.com/kjbekkelund/karma-requirejs
 
 


### PR DESCRIPTION
It's "always" bothered me that a Google search for "karma requirejs" brings up a link to the Karma 0.8 docs, and then I went to the Github project page and the README links to the 0.8 docs too.  

Fixed the link to point to the current Karma docs :)