### PR TITLE
Run tests on node's latest available 4.x version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - 4
 
 before_install:
 


### PR DESCRIPTION
The Travis config in the current revision specifies node v0.10. Which is pretty outdated. This PR configures Travis to run the test suite on the latest available 4.x. instead.